### PR TITLE
Test the module under puppet 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,15 @@
 version: 2.1
 jobs:
   build:
-    docker: 
-      - image: circleci/ruby:2.5.0
+    docker:
+      - image: cimg/ruby:2.7
     steps:
       - checkout
       - run:
           name: "Install the dependencies"
           command: bundle install --jobs=4 --retry=3
           environment:
-            PUPPET_GEM_VERSION: "~> 6.10.0"
-      - run: 
+            PUPPET_GEM_VERSION: "~> 7.6.1"
+      - run:
           name: "Run the specs"
           command: bundle exec rake spec


### PR DESCRIPTION
Puppet 7 bundles ruby 2.7 rather than 2.5 so change the CircleCI tests
to use that. And they changed the container name so bump that too

`This image is designed to supercede the legacy CircleCI Ruby image, circleci/ruby.`
https://circleci.com/developer/images/image/cimg/ruby