### PR TITLE
Update rubocop cop setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Bundler/DuplicatedGem:
   Enabled: false
 
 Metrics/BlockLength:
-  ExcludedMethods: ['describe']
+  IgnoredMethods: ['describe']
   Max: 35
 
 Metrics/MethodLength:


### PR DESCRIPTION
```Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.```