### PR TITLE
Change Env var fetch to return `nil` on absent value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 2.10.0'
 end
 
-if (puppetversion = ENV['PUPPET_GEM_VERSION'])
+if (puppetversion = ENV.fetch('PUPPET_GEM_VERSION', nil))
   gem 'puppet', puppetversion, require: false
 else
   gem 'puppet', require: false


### PR DESCRIPTION
Instead of throwing an error. Prompted by rubocop

```
Gemfile:13:21: C: [Correctable] Style/FetchEnvVar: Use
ENV.fetch('PUPPET_GEM_VERSION') or ENV.fetch('PUPPET_GEM_VERSION', nil)
instead of ENV['PUPPET_GEM_VERSION']. if (puppetversion =
ENV['PUPPET_GEM_VERSION']) ```